### PR TITLE
Add AlreadyMember error, remove-member endpoints, update CORS

### DIFF
--- a/src/Simpchat.Application/Errors/ApplicationErrors.cs
+++ b/src/Simpchat.Application/Errors/ApplicationErrors.cs
@@ -47,13 +47,18 @@ namespace Simpchat.Application.Errors
                 );
 
             public static readonly Error EmailAlreadyExists = new Error(
-                "User.UsernameAlreadyExists",
+                "User.EmailAlreadyExists",
                 "User with given [EMAIL] already exists"
                 );
 
             public static readonly Error NotParticipatedInChat = new Error(
                 "User.NotParticipatedInChat",
                 "User not participated in [CHAT] to perform [ACTION]"
+                );
+
+            public static readonly Error AlreadyMember = new Error(
+                "User.AlreadyMember",
+                "User is already a member of this chat"
                 );
 
             public static readonly Error CanNotDeleteAdmin = new Error(

--- a/src/Simpchat.Application/Extentions/ResultToApiExtentions.cs
+++ b/src/Simpchat.Application/Extentions/ResultToApiExtentions.cs
@@ -73,18 +73,34 @@ namespace Simpchat.Application.Extentions
                 "UserReaction.NotFoundWithUserIdAndReactionId" or
                 "Notification.IdNotFound" or
                 "GlobalRole.NameNotFound" or
-                "Chat.Permission.NameNotFound" => (int)HttpStatusCode.NotFound,
+                "Chat.Permission.NameNotFound" or
+                "Chat.Ban.NotFound" or
+                "User.Ban.NotFound" or
+                "Message.Pinning.NotPinned" => (int)HttpStatusCode.NotFound,
 
                 // Conflicts
                 "User.UsernameAlreadyExists" or
-                "User.EmailAlreadyExists" => (int)HttpStatusCode.Conflict,
+                "User.EmailAlreadyExists" or
+                "User.AlreadyMember" or
+                "Chat.Ban.AlreadyBanned" or
+                "User.Ban.AlreadyBanned" or
+                "Message.Pinning.AlreadyPinned" => (int)HttpStatusCode.Conflict,
 
                 // Forbidden actions
                 "User.NotParticipatedInChat" or
                 "User.CanNotDeleteAdmin" or
-                "Chat.Permission.Denied" => (int)HttpStatusCode.Forbidden,
+                "Chat.Permission.Denied" or
+                "Chat.Ban.UserBanned" or
+                "Chat.Ban.CannotBanOwner" or
+                "User.Ban.UserBanned" or
+                "User.Ban.CannotMessageBannedUser" => (int)HttpStatusCode.Forbidden,
 
-                "Chat.NotValidChatType" => (int)HttpStatusCode.BadRequest,
+                "Chat.NotValidChatType" or
+                "Chat.Ban.CannotBanSelf" or
+                "User.Ban.CannotBanSelf" or
+                "Message.Pinning.PinLimitReached" or
+                "File.TooLarge" or
+                "File.InvalidType" => (int)HttpStatusCode.BadRequest,
 
                 "Otp.Expired" => (int)HttpStatusCode.Gone,
 

--- a/src/Simpchat.Application/Features/ChannelService.cs
+++ b/src/Simpchat.Application/Features/ChannelService.cs
@@ -101,7 +101,7 @@ namespace Simpchat.Application.Features
 
             if (channel.IsChannelSubscriber(userId))
             {
-                return Result.Failure(ApplicationErrors.User.NotParticipatedInChat);
+                return Result.Failure(ApplicationErrors.User.AlreadyMember);
             }
 
             var channelSubscriber = new ChannelSubscriber
@@ -152,7 +152,7 @@ namespace Simpchat.Application.Features
                 return Result.Failure(new Error("Channel.Private", "Cannot join private channel"));
 
             if (channel.IsChannelSubscriber(userId))
-                return Result.Failure(ApplicationErrors.User.NotParticipatedInChat);
+                return Result.Failure(ApplicationErrors.User.AlreadyMember);
 
             var channelSubscriber = new ChannelSubscriber
             {

--- a/src/Simpchat.Application/Features/GroupService.cs
+++ b/src/Simpchat.Application/Features/GroupService.cs
@@ -106,7 +106,7 @@ namespace Simpchat.Application.Features
 
             if (group.IsGroupMember(userId))
             {
-                return Result.Failure(ApplicationErrors.User.NotParticipatedInChat);
+                return Result.Failure(ApplicationErrors.User.AlreadyMember);
             }
 
             await _repo.AddMemberAsync(userId, groupId);
@@ -153,7 +153,7 @@ namespace Simpchat.Application.Features
                 return Result.Failure(new Error("Group.Private", "Cannot join private group"));
 
             if (group.IsGroupMember(userId))
-                return Result.Failure(ApplicationErrors.User.NotParticipatedInChat);
+                return Result.Failure(ApplicationErrors.User.AlreadyMember);
 
             await _repo.AddMemberAsync(userId, groupId);
 

--- a/src/Simpchat.Web/Controllers/ChannelController.cs
+++ b/src/Simpchat.Web/Controllers/ChannelController.cs
@@ -90,6 +90,18 @@ namespace Simpchat.Web.Controllers
             return apiResponse.ToActionResult();
         }
 
+        [HttpPost("remove-member")]
+        [Authorize]
+        public async Task<IActionResult> RemoveMemberAsync(Guid chatId, Guid removingUserId)
+        {
+            var requesterId = Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier));
+
+            var response = await _channelService.DeleteSubscriberAsync(removingUserId, chatId, requesterId);
+            var apiResponse = response.ToApiResult();
+
+            return apiResponse.ToActionResult();
+        }
+
         [HttpDelete]
         [Authorize]
         public async Task<IActionResult> DeleteAsync(Guid chatId)

--- a/src/Simpchat.Web/Controllers/GroupController.cs
+++ b/src/Simpchat.Web/Controllers/GroupController.cs
@@ -87,6 +87,18 @@ namespace Simpchat.Web.Controllers
             return apiResponse.ToActionResult();
         }
 
+        [HttpPost("remove-member")]
+        [Authorize]
+        public async Task<IActionResult> RemoveMemberAsync(Guid chatId, Guid removingUserId)
+        {
+            var requesterId = Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier));
+
+            var response = await _groupService.DeleteMemberAsync(removingUserId, chatId, requesterId);
+            var apiResponse = response.ToApiResult();
+
+            return apiResponse.ToActionResult();
+        }
+
         [HttpDelete]
         [Authorize]
         public async Task<IActionResult> DeleteAsync(Guid chatId)

--- a/src/Simpchat.Web/Program.cs
+++ b/src/Simpchat.Web/Program.cs
@@ -54,7 +54,8 @@ builder.Services.AddCors(options =>
                 "http://localhost:5185",
                 "http://localhost:5180",
                 "http://192.168.100.25:5173",
-                "http://10.30.0.112:5173"
+                "http://10.30.0.112:5173",
+                "http://10.30.13.110:5185"
             )
             .AllowAnyHeader()
             .AllowAnyMethod()


### PR DESCRIPTION
Introduce ApplicationErrors.User.AlreadyMember for join attempts by existing members, replacing NotParticipatedInChat in relevant services. Update HTTP status code mappings for new error cases. Add POST /remove-member endpoints to ChannelController and GroupController for member removal. Expand CORS policy to include http://10.30.13.110:5185.